### PR TITLE
Jukebox and Jukebox Advanced Conquered

### DIFF
--- a/lib/advanced_jukebox.rb
+++ b/lib/advanced_jukebox.rb
@@ -1,31 +1,62 @@
+
+
+
+
+
 #Here is the song hash you will be working with. Each key is a song name and each value is the location of it's mp3 file.
 #make sure to edit the value of each key to replace < path to this directory >
 #with the correct path to this directory on your computer
 
-# my_songs = {
-# "Go Go GO" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/01.mp3',
-# "LiberTeens" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/02.mp3',
-# "Hamburg" =>  '< path to this directory >/jukebox-cli/audio/Emerald-Park/03.mp3',
-# "Guiding Light" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/04.mp3',
-# "Wolf" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/05.mp3',
-# "Blue" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/06.mp3',
-# "Graduation Failed" => '< path to this directory >/jukebox-cli/audio/Emerald-Park/07.mp3'
-# }
+def my_songs 
+{
+"Go Go GO" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/01.mp3',
+"LiberTeens" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/02.mp3',
+"Hamburg" =>  '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/03.mp3',
+"Guiding Light" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/04.mp3',
+"Wolf" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/05.mp3',
+"Blue" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/06.mp3',
+"Graduation Failed" => '/Users/MMac/Coding/Prework/labs/jukebox-cli-001-prework-web/audio/Emerald-Park/07.mp3'
+ }
+end
 
 def help
-  #this method should be the same as in jukebox.rb
+  puts "I accept the following commands"
+  puts "- help : displays this message
+- list : displays a list of songs you can play
+- play : lets you choose a song to play
+- exit : exits this program"
 
+end
+
+def help_prompt
+  puts "I accept the following commands"
+  puts "- help : displays this message
+- list : displays a list of songs you can play
+- play : lets you choose a song to play
+- exit : exits this program"
 end
 
 
 
 def list(my_songs)
-  #this method is different! Collect the keys of the my_songs hash and 
-  #list the songs by name
+  my_songs.each do |key, value|
+    puts key
+  end
 end
 
 
 def play(my_songs)
+  puts "Please enter a song name or number:"
+    choice = gets.chomp
+      if my_songs.keys.include?(choice)
+        puts "Playing #{choice}"
+        system "open #{my_songs[choice]}"
+      else
+        puts "Invalid input, please try again."
+      end
+    end
+
+
   #this method is slightly different!
   #you should still ask the user for input and collect their song choice
   #this time, only allow user's to input a song name
@@ -34,12 +65,28 @@ def play(my_songs)
   #if it is, play the song using the system 'open <file path>' syntax
   #get the file path of the song by looking it up in the my_songs hash
   
-end
 
 def exit_jukebox
-  #this method is the same as in jukebox.rb
+  puts "Goodbye."
 end
 
 def run(my_songs)
-  #this method is the same as in jukebox.rb
+  prompt = "Please enter a command:"
+  puts prompt
+    while command = gets.chomp
+    case command 
+    when "list"
+      list(my_songs)
+      puts prompt
+    when "play"
+      play(my_songs)
+      puts prompt
+    when "help"
+      help_prompt
+      puts prompt
+    when "exit"
+      exit_jukebox
+      break
+    end
+  end
 end

--- a/lib/jukebox.rb
+++ b/lib/jukebox.rb
@@ -1,4 +1,7 @@
-songs = [
+require 'pry'
+
+def song_list
+  [
   "Phoenix - 1901",
   "Tokyo Police Club - Wait Up",
   "Sufjan Stevens - Too Much",
@@ -7,6 +10,73 @@ songs = [
   "The Cults - Abducted",
   "Phoenix - Consolation Prizes",
   "Harry Chapin - Cats in the Cradle",
-  "Amos Lee - Keep It Loose, Keep It Tight"
+  "Amos Lee - Keep It Loose, Keep It Tight",
 ]
+end
+
+def help_prompt
+  puts "I accept the following commands"
+  puts "- help : displays this message
+- list : displays a list of songs you can play
+- play : lets you choose a song to play
+- exit : exits this program"
+end
+
+def help 
+  puts "I accept the following commands"
+  puts "- help : displays this message
+- list : displays a list of songs you can play
+- play : lets you choose a song to play
+- exit : exits this program"
+end
+
+def list(songs)
+  count = 1
+    songs.each do |x|
+      puts "#{count}. #{x}"
+      count += 1
+    end
+
+end
+
+def play(songs) # devil method
+  puts "Please enter a song name or number:"
+  choice = gets.chomp
+  if songs.include?(choice)
+    puts "Playing #{choice}"
+  elsif choice.to_i != 0 && choice.to_i <= 9
+    puts "Playing #{songs[choice.to_i - 1]}"
+  else
+    puts "Invalid input, please try again."
+  end
+end
+
+
+
+def exit_jukebox
+  puts "Goodbye."
+end
+
+def run(songs)
+  prompt = "Please enter a command:"
+  puts prompt
+    while command = gets.chomp
+    case command 
+    when "list"
+      list(songs)
+      puts prompt
+    when "play"
+      play(songs)
+      puts prompt
+    when "help"
+      help_prompt
+      puts prompt
+    when "exit"
+      exit_jukebox
+      break
+    end
+  end
+end
+
+
 


### PR DESCRIPTION
Finishing this lab wasn't as hard as I anticipated yet it presented itself with it's fair share of challenges.

The two methods I'm going to focus on are the `play(argument)` and `run(argument)` methods.

First `play`, check it out: 
```
def play(songs) # devil method
  puts "Please enter a song name or number:"
  choice = gets.chomp
  if songs.include?(choice)
    puts "Playing #{choice}"
  elsif choice.to_i != 0 && choice.to_i <= 9
    puts "Playing #{songs[choice.to_i - 1]}"
  else
    puts "Invalid input, please try again."
  end
end
```
Contrary to what I believed it was not necessary to iterate over the argument. Instead checking the argument which in this case was an array `.include?(arg)` sufficed.  Looking at the method you can see that `songs` is checked to see if it includes the `choice` then if it's true boom 
`puts "Playing #{choice}"`.

The `elsif` statement then checks if the `choice` variable is an integer or string. I was informed by a fellow Flatironer that a string.to_i will equal 0, unless it's an integer that is a string to begin with, like `"9".to_i` will be equal to 9 (the integer and can be added to, subtracted, whatever). Also knowing how long the track list is using the `&&` we add the extra layer to the conditional, so if it passes both tests we get
`puts "Playing #{songs[choice.to_i - 1]}"`. So `songs` is an array and `songs[choice.to_i - 1]` is calling on the index number of that array. But since the array indexing process starts at 0, we minus 1 from the digit being passed in as the `choice` variable. **Remember** this `play` method is built to accept either the number of the track or it's entire name.

The second method I want to talk about is `run`
```
def run(songs)
  prompt = "Please enter a command:"
  puts prompt
    while command = gets.chomp
    case command 
    when "list"
      list(songs)
      puts prompt
    when "play"
      play(songs)
      puts prompt
    when "help"
      help_prompt
      puts prompt
    when "exit"
      exit_jukebox
      break
    end
  end
end
```
The `when` case statement was cute here, but the loop at play here was what I found most challenging. 
It all starts at the top: 
```
while command = gets.chomp
case command
```
The while loop here will continue to run until it hits a `when` that includes `break`. "list", "play", "help" do not include `break`, so when I type "list" for example I get this:
```
1. Phoenix - 1901
2. Tokyo Police Club - Wait Up
3. Sufjan Stevens - Too Much
4. The Naked and the Famous - Young Blood
5. (Far From) Home - Tiga
6. The Cults - Abducted
7. Phoenix - Consolation Prizes
8. Harry Chapin - Cats in the Cradle
9. Amos Lee - Keep It Loose, Keep It Tight
Please enter a command:
#while command = gets.chomp
```
Since there is no `break` the loop will keep going taking in more and more new `command` variables, unless you type in "exit" which indeed has a `break`. This was a good exercise in looping and making a functional program which I hope to use in the future for my own purposes.